### PR TITLE
adds correct timestamp handling

### DIFF
--- a/lib/data/schemas/test.ex
+++ b/lib/data/schemas/test.ex
@@ -1,11 +1,12 @@
 defmodule ExTest.Schemas.Test do
-    use Ecto.Schema
+  use Ecto.Schema
 
-    schema "test" do
-        #field :id, :integer is always set by ecto
-        field :bla, :string
-        field :id_again, :integer
-        field :blup, :float, default: 0.0
-        field :mach_doch, :integer
-    end
+  schema "test" do
+    #field :id, :integer is always set by ecto
+    field :bla, :string
+    field :id_again, :integer
+    field :blup, :float, default: 0.0
+    field :mach_doch, :integer
+    timestamps()
+  end
 end

--- a/priv/test/migrations/20170503150023_add_test_table.exs
+++ b/priv/test/migrations/20170503150023_add_test_table.exs
@@ -3,20 +3,15 @@ defmodule ExTest.Repos.Test.Migrations.AddTestTable do
 
   def up do
 
-      create table(:test) do
-        add :bla, :string
-        add :id_again, :integer
-        add :blup, :float, default: 0.0
-        timestamps()
-      end
-
-      alter table(:test) do
-        modify :inserted_at, :utc_datetime, default: fragment("NOW()")
-        modify :updated_at, :utc_datetime, default: fragment("NOW()")
-      end
+    create table(:test) do
+      add :bla, :string
+      add :id_again, :integer
+      add :blup, :float, default: 0.0
+      timestamps()
     end
+  end
 
-    def down do
-      drop table(:test)
-    end
+  def down do
+    drop table(:test)
+  end
 end


### PR DESCRIPTION
The timestamps() macro must be used in both schema and migration. Then it's working as expected.