### PR TITLE
mix instead of shell scripts

### DIFF
--- a/lib/mix/tasks/docker.ex
+++ b/lib/mix/tasks/docker.ex
@@ -1,0 +1,8 @@
+defmodule Mix.Tasks.Docker do
+  use Mix.Task
+
+  def run(_) do
+    Mix.Tasks.Cmd.run(~w(docker build -t ex-test:latest .))
+    Mix.Tasks.Cmd.run(~w(docker run -i --rm --name ex-test -p 8080:8080 ex-test:latest))
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,8 @@ defmodule ExTest.Mixfile do
       elixir: "~> 1.3",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      deps: deps()
+      deps: deps(),
+      aliases: aliases()
     ]
   end
 
@@ -24,6 +25,12 @@ defmodule ExTest.Mixfile do
         :gproc,
         #:xandra
       ]
+    ]
+  end
+
+  defp aliases do
+    [
+      start: ["clean", "compile", "run --no-halt"]
     ]
   end
 


### PR DESCRIPTION
adds custom mix task example for docker (no TTY though)
adds alias for run.sh as mix start